### PR TITLE
Parallel version has also been implemented for python.

### DIFF
--- a/quad-py/tests/test_parallel.py
+++ b/quad-py/tests/test_parallel.py
@@ -1,15 +1,18 @@
 import quad
 import math
 import time
+import timeit
 
-max = 3
-var = range(max)
-a = 0.0
-b = 10000.0
-limit = 100000
+import numpy as np
 
 
 def test_parallel():
+    max = 3
+    var = range(max)
+    a = 0.0
+    b = 10000.0
+    limit = 100000
+
     for k in var:
         f = lambda x: (math.cos(x), math.sin(x))
 
@@ -28,3 +31,31 @@ def test_parallel():
         print("serial res : ", res.result)
         print("serial err : ", res.abserr)
         print("serial last : ", res.more_info[1])
+
+
+def test_parallel_2():
+    number = 100
+    a = 0.0
+    b = 10000.0
+    limit = 1000000
+
+    f = lambda x: (
+        math.cos(x),
+        math.sin(x),
+        math.cos(x),
+        math.cos(x),
+        math.sin(x),
+        math.cos(x),
+    )
+
+    def bench(test_call):
+        times = timeit.repeat(test_call, number=number)
+        print(times)
+        res = test_call()
+        return min(times), np.array(res.result), res.abserr
+
+    stime, sres, serr = bench(lambda: quad.qag(f, a, b, limit=limit))
+    ptime, pres, perr = bench(lambda: quad.qag_par(f, a, b, limit=limit))
+
+    print(f"\nratio: {ptime / stime * 100:.2f}%")
+    print("distances:", (pres - sres) / (perr + serr))


### PR DESCRIPTION
quad.qag_par  seems to run fine if executed once.
If it is executed several times ( as in parallel_test.py with max other than 1), however, performance drops dramatically (it becomes much worse than in the non-parallel case).